### PR TITLE
ユーザー登録機能のJPA対応

### DIFF
--- a/src/main/java/com/example/controller/UserController.java
+++ b/src/main/java/com/example/controller/UserController.java
@@ -55,7 +55,7 @@ public class UserController {
 	public String registrationUser(UsersForm form, Model model) throws NoSuchAlgorithmException {
 		Users result = userService.checkEmail(form);
 		model.addAttribute("registrateUser", form);
-		if (result == null) {
+		if (result != null) {
 			session.setAttribute("error", "このメールアドレスは使用されています。");
 			return "user_registrate";
 		} else {
@@ -65,16 +65,26 @@ public class UserController {
 	}
 
 	/**
-	 * ユーザー登録完了画面表示
+	 * ユーザー登録
 	 * 
 	 * @param form
 	 * @return
 	 * @throws NoSuchAlgorithmException
 	 */
-	@RequestMapping("/registrationComplete")
-	public String registrationComplete(UsersForm form) throws NoSuchAlgorithmException {
+	@RequestMapping("/registrationCheck")
+	public String registrationCheck(UsersForm form) throws NoSuchAlgorithmException {
 		userService.insertUsers(form);
 		session.removeAttribute("error");
+		return "redirect:/user/registrationComplete";
+	}
+
+	/**
+	 * ユーザー情報の登録完了後に登録完了画面表示
+	 * 
+	 * @return
+	 */
+	@RequestMapping("/registrationComplete")
+	public String registrationComplete() {
 		return "registration_complete";
 	}
 

--- a/src/main/java/com/example/repository/UsersRepository.java
+++ b/src/main/java/com/example/repository/UsersRepository.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.NoResultException;
+import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
@@ -36,6 +37,8 @@ public class UsersRepository {
 			TypedQuery<Users> query = entityManager.createQuery(jpql, Users.class);
 			query.setParameter("email", form.getEmail());
 			return query.getSingleResult();
+		} catch (NonUniqueResultException e) {
+			return null;
 		} catch (NoResultException e) {
 			return null;
 		}
@@ -84,7 +87,6 @@ public class UsersRepository {
 	 * @param timestamp
 	 */
 	public void deleteInvalidToken(Timestamp timestamp) {
-		System.out.println(timestamp);
 		try {
 			EntityManager entityManager = entityManagerFactory.createEntityManager();
 			entityManager.getTransaction().begin();

--- a/src/main/resources/templates/registration_complete.html
+++ b/src/main/resources/templates/registration_complete.html
@@ -7,7 +7,9 @@
 <body>
 <h3>登録完了しました！</h3>
 <span>ご利用ありがとうございます！</span>
-<form th:action="/todoList/login">ログイン</form>
+<form th:action="@{/user/login}">
+	<button>ログイン</button>
+</form>
 
 
 </body>

--- a/src/main/resources/templates/registration_confirmation.html
+++ b/src/main/resources/templates/registration_confirmation.html
@@ -16,21 +16,12 @@
 		<div>パスワード</div>
 		<div>********</div>
 		<input type="hidden" th:field="*{password}" name="password">
-		<div>秘密の質問1</div>
-		<div th:text="${user.secretQuestion1}"></div>
-		<input type="hidden" th:field="*{secretQuestion1}" name="secretQuestion1">
 		<div>秘密の質問1の答え</div>
 		<div th:text="${user.secretAnswer1}"></div>
 		<input type="hidden" th:field="*{secretAnswer1}" name="secretAnswer1">
-		<div>秘密の質問2</div>
-		<div th:text="${user.secretQuestion2}"></div>
-		<input type="hidden" th:field="*{secretQuestion2}" name="secretQuestion2">
 		<div>秘密の質問2の答え</div>
 		<div th:text="${user.secretAnswer2}"></div>
 		<input type="hidden" th:field="*{secretAnswer2}" name="secretAnswer2">
-		<div>秘密の質問3</div>
-		<div th:text="${user.secretQuestion3}"></div>
-		<input type="hidden" th:field="*{secretQuestion3}" name="secretQuestion3">
 		<div>秘密の質問3の答え</div>
 		<div th:text="${user.secretAnswer3}"></div>
 		<input type="hidden" th:field="*{secretAnswer3}" name="secretAnswer3">

--- a/src/main/resources/templates/todo_login.html
+++ b/src/main/resources/templates/todo_login.html
@@ -14,6 +14,9 @@
 		<input type="password" name="password" th:field="*{password}">
 		<button>ログイン</button>
 	</form>
+	<span>ユーザー登録は</span>
+	<span><a th:href="@{/user/registration}">こちら</a></span>
+	<br>
 	<span>パスワードを忘れた方は</span>
 	<span><a th:href="@{/user/resetPassword}">こちら</a></span>
 

--- a/src/main/resources/templates/user_registrate.html
+++ b/src/main/resources/templates/user_registrate.html
@@ -16,17 +16,14 @@
 		<input type="password" name="password"> <br>
 		<div>確認用パスワード</div>
 		<input type="password"> <br>
-		<div>秘密の質問1</div>
-		<input type="text" th:field="*{secretQuestion1}" name="secretQuestion1"> <br>
-		<div>秘密の質問1の答え</div>
+		<br>
+		<div>以下の質問は、パスワードを忘れた際に使用します。</div>
+		<br>
+		<div>好きな映画のタイトルは？</div>
 		<input type="text" th:field="*{secretAnswer1}" name="secretAnswer1"> <br>
-		<div>秘密の質問2</div>
-		<input type="text" th:field="*{secretQuestion2}" name="secretQuestion2"> <br>
-		<div>秘密の質問2の答え</div>
+		<div>子どものころに読んでいた本のタイトルは？</div>
 		<input type="text" th:field="*{secretAnswer2}" name="secretAnswer2"> <br>
-		<div>秘密の質問3</div>
-		<input type="text" th:field="*{secretQuestion3}" name="secretQuestion3"> <br>
-		<div>秘密の質問3の答え</div>
+		<div>好きな食べ物は？</div>
 		<input type="text" th:field="*{secretAnswer3}" name="secretAnswer3"> <br>
 		<button>確認</button>
 		<button type="reset">リセット</button>


### PR DESCRIPTION
・秘密の質問を統一したものに変更
・ユーザー登録完了画面をリダイレクト後に表示するよう変更。
　→以前のままだと完了画面を更新すると再度同じ情報がDBに登録されてしまうため