### PR TITLE
フォームの不具合修正

### DIFF
--- a/src/main/java/com/example/controller/MyPageController.java
+++ b/src/main/java/com/example/controller/MyPageController.java
@@ -148,9 +148,14 @@ public class MyPageController {
 	 * @throws NoSuchAlgorithmException
 	 */
 	@RequestMapping("/changePasswordComplete")
-	public String changePasswordComplete(String token, UsersForm form, Model model) throws NoSuchAlgorithmException {
+	public String changePasswordComplete(String token, UsersForm form, BindingResult result, Model model)
+			throws NoSuchAlgorithmException {
 		String view = "mypage_top";
 		view = checkToken(token, view, model);
+		if (form.getPassword().equals("") || form.getPassword() == null) {
+			model.addAttribute("error", "パスワードを入力してください");
+			return "changePasswordFromMypage";
+		}
 		if (view.equals("mypage_top")) {
 			token = (String) model.getAttribute("token");
 			userService.updatePassword(form);

--- a/src/main/java/com/example/controller/UserController.java
+++ b/src/main/java/com/example/controller/UserController.java
@@ -7,6 +7,8 @@ import javax.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -55,10 +57,14 @@ public class UserController {
 	 * @throws NoSuchAlgorithmException
 	 */
 	@RequestMapping("/registrationConfirmation")
-	public String registrationUser(UsersForm form, Model model) throws NoSuchAlgorithmException {
-		Users result = userService.checkEmail(form);
+	public String registrationUser(@Validated UsersForm form, BindingResult result, Model model)
+			throws NoSuchAlgorithmException {
+		if (result.hasErrors()) {
+			return "user_registrate";
+		}
+		Users results = userService.checkEmail(form);
 		model.addAttribute("registrateUser", form);
-		if (result != null) {
+		if (results != null) {
 			session.setAttribute("error", "このメールアドレスは使用されています。");
 			return "user_registrate";
 		} else {

--- a/src/main/java/com/example/form/UsersForm.java
+++ b/src/main/java/com/example/form/UsersForm.java
@@ -1,16 +1,29 @@
 package com.example.form;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 
 public class UsersForm {
 
 	private Integer id;
+
+	@NotBlank(message = "ユーザー名を入力してください")
 	private String name;
-	@Email
+
+	@Email(message = "不正な入力です")
+	@NotBlank(message = "メールアドレスを入力してください")
 	private String email;
+
+	@NotBlank(message = "パスワードを入力してください")
 	private String password;
+
+	@NotBlank(message = "質問1に回答してください")
 	private String secretAnswer1;
+
+	@NotBlank(message = "質問2に回答してください")
 	private String secretAnswer2;
+
+	@NotBlank(message = "質問3に回答してください")
 	private String secretAnswer3;
 
 	public Integer getId() {

--- a/src/main/resources/templates/changePasswordFromMypage.html
+++ b/src/main/resources/templates/changePasswordFromMypage.html
@@ -9,15 +9,18 @@
 	<header th:insert="todoList :: frag_header"></header>
 	<div>新しいパスワードを入力してください</div>
 	<div>※パスワードの再設定が完了すると、マイページに戻ります。</div>
+	<div>※パスワードと確認用パスワードが未入力または不一致の場合、パスワード変更は機能しません。</div>
+	<div id="noMatchPassword" style="color: red"></div>
 	<form th:action="@{/myPage/changePasswordComplete}" method="post" th:object="${usersForm}">
 		<div id="noMatchPassword" style="color: red"></div>
 		<input type="hidden" name="token" th:value="${token}">
 		<input type="hidden" name="email" th:field="*{email}">
+		<div th:text="${error}" style="color: red"></div>
 		<div>新しいパスワード</div>
-		<input type="password" name="password" th:field="*{password}">
+		<input type="password" name="password" id="password" th:field="*{password}">
 		<div>新しいパスワード（確認用）</div>
-		<input type="password" name="cpassword">
-		<button class="button">パスワード変更</button>
+		<input type="password" name="checkPassword" id="checkPassword"> <br>
+		<button class="button" id="submit">パスワード変更</button>
 	</form>
 	
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>

--- a/src/main/resources/templates/change_password.html
+++ b/src/main/resources/templates/change_password.html
@@ -14,7 +14,7 @@
 		<div>新しいパスワード</div>
 		<input type="password" name="password" th:field="*{password}" id="password">
 		<div>新しいパスワード（確認用）</div>
-		<input type="password" name="cpassword" id="checkPassword">
+		<input type="password" name="cpassword" id="checkPassword"> <br>
 		<button class="button">パスワード変更</button>
 	</form>
 	

--- a/src/main/resources/templates/secret_question.html
+++ b/src/main/resources/templates/secret_question.html
@@ -9,12 +9,12 @@
 	<span th:text="${error}"></span>
 	<form th:action="@{/user/changePassword}" th:object="${usersForm}" method="post">
 		<input type="hidden" name="email" th:field="*{email}">
-		<div>秘密の質問1</div>
+		<div>質問1：好きな映画のタイトルは？</div>
 		<input type="text" name="secretAnswer1" th:field="*{secretAnswer1}">
-		<div>秘密の質問2</div>
+		<div>質問2：子どものころに読んでいた本のタイトルは？</div>
 		<input type="text" name="secretAnswer2" th:field="*{secretAnswer2}">
-		<div>秘密の質問3</div>
-		<input type="text" name="secretAnswer3" th:field="*{secretAnswer3}">
+		<div>質問3：好きな食べ物は？</div>
+		<input type="text" name="secretAnswer3" th:field="*{secretAnswer3}"> <br>
 		<button class="button">送信</button>
 	</form>
 

--- a/src/main/resources/templates/user_registrate.html
+++ b/src/main/resources/templates/user_registrate.html
@@ -7,10 +7,14 @@
 </head>
 <body>
 	<h2>ユーザー登録</h2>
+	<div>下記登録情報を入力してください。</div>
+	<div>※パスワードと確認用パスワードが未入力または不一致の場合、登録ボタンは機能しません。</div>
 	<div th:text="${session.error}" style="color: red"></div>
 	<form th:action="@{/user/registrationConfirmation}" method="post" th:object="${usersForm}" id="usersForm">
+		<div th:errors="*{name}" style="color: red"></div>
 		<div>ユーザー名</div>
 		<input type="text" th:field="*{name}" name="name" id="name"> <br>
+		<div th:errors="*{email}" style="color: red"></div>
 		<div>メールアドレス</div>
 		<input type="email" th:field="*{email}" name="email" id="email"> <br>
 		<div id="noMatchPassword" style="color: red"></div>
@@ -21,11 +25,14 @@
 		<br>
 		<div>以下の質問は、パスワードを忘れた際に使用します。</div>
 		<br>
-		<div>好きな映画のタイトルは？</div>
+		<div th:errors="*{secretAnswer1}" style="color: red"></div>
+		<div>質問1：好きな映画のタイトルは？</div>
 		<input type="text" th:field="*{secretAnswer1}" name="secretAnswer1" id="secretAnswer1"> <br>
-		<div>子どものころに読んでいた本のタイトルは？</div>
+		<div th:errors="*{secretAnswer2}" style="color: red"></div>
+		<div>質問2：子どものころに読んでいた本のタイトルは？</div>
 		<input type="text" th:field="*{secretAnswer2}" name="secretAnswer2" id="secretAnswer2"> <br>
-		<div>好きな食べ物は？</div>
+		<div th:errors="*{secretAnswer3}" style="color: red"></div>
+		<div>質問3：好きな食べ物は？</div>
 		<input type="text" th:field="*{secretAnswer3}" name="secretAnswer3" id="secretAnswer3"> <br>
 		<button id="submit" class="button">確認</button>
 	</form>

--- a/src/main/resources/templates/user_secession.html
+++ b/src/main/resources/templates/user_secession.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" th:href="@{../css/common.css}" />
 </head>
 <body>
+	<header th:insert="todoList :: frag_header"></header>
 	<h2>退会手続き</h2>
 	<div>退会手続きを行います。一度退会するとアカウントを復活させることが出来ません。</div>
 	<div th:text=${error} style="color: red">パスワード不一致</div>


### PR DESCRIPTION
・ログイン後のパスワード変更についてはBindingResultを使用するとほかの項目のバリデーションエラーまで取得してしまうため、空文字もしくはnullの場合はエラーメッセージを表示するように設計
・パスワードと確認用パスワードが一致しないとボタンが活性化しないことを明記
・入力必須項目についてフォームクラスにバリデーションを付加